### PR TITLE
Fix bug print vips

### DIFF
--- a/sourcemod/scripting/include/vip/mtd_maps.inc
+++ b/sourcemod/scripting/include/vip/mtd_maps.inc
@@ -299,14 +299,16 @@ methodmap Player < Entity
 
 		iLen = strcopy(szText, sizeof(szText), "VIPy Online: ");
 
-		if(g_adtVips.Length)
+		int iLenArray = g_adtVips.Length;
+
+		if(iLenArray)
 		{
-			for(int i=0; i<g_adtVips.Length; i++)
+			for(int i=0; i<iLenArray; i++)
 			{
 				client = Player(g_adtVips.Get(i));
 				client.GetName(szName, sizeof(szName));
 
-				if(!(i+1 == g_adtVips.Length))
+				if(!(i+1 == iLenArray))
 					iLen += FormatEx(szText[iLen], sizeof(szText)-iLen, "\x04%s\x01,", szName);
 				else
 					iLen += FormatEx(szText[iLen], sizeof(szText)-iLen, "\x04%s\x01.", szName);

--- a/sourcemod/scripting/vip.sp
+++ b/sourcemod/scripting/vip.sp
@@ -654,6 +654,11 @@ public void OnClientDisconnect(int client)
 	{
 		client_pl.vip = false;
 		client_pl.disturbed = false;
+
+		int iIndex = g_adtVips.FindValue(client);
+
+		if(iIndex != -1)
+			g_adtVips.Erase(iIndex);
 	}
 }
 

--- a/sourcemod/scripting/vip.sp
+++ b/sourcemod/scripting/vip.sp
@@ -745,4 +745,6 @@ public void OnPluginEnd()
 	UnhookEvent("cs_intermission", EndRestartMatch, EventHookMode_PostNoCopy);
 	UnhookEvent("player_spawn", PlayerSpawn, EventHookMode_Post);
 	UnhookEvent("player_team", PlayerTeamEvent, EventHookMode_Pre);
+
+	g_adtVips.Clear();
 }


### PR DESCRIPTION
It fixes bug, that occurs when the disconnected vips were not removed from an array and after execute vips command an error was printed "Client x is not in game"
