### PR TITLE
Fix bug with defuser at spawn

### DIFF
--- a/sourcemod/scripting/vip.sp
+++ b/sourcemod/scripting/vip.sp
@@ -683,8 +683,8 @@ public void PlayerSpawn(Event event, const char[] name, bool dontBroadcast)
 		
 		client_pl.SetProp(Prop_Send, "m_iAccount", (iMoney+iAddMoney >= iMaxMoney) ? iMaxMoney : iMoney+iAddMoney);
 		
-		if(client_pl.team == CS_TEAM_CT)
-			client_pl.SetProp(Prop_Send, "m_bHasDefuser", g_pDefuser.BoolValue);
+		if(client_pl.team == CS_TEAM_CT && g_pDefuser.BoolValue)
+			client_pl.SetProp(Prop_Send, "m_bHasDefuser", true);
 
 		if(g_pTaser.BoolValue)
 			client_pl.GiveItem("weapon_taser");


### PR DESCRIPTION
It fixes a bug with defuser when a player spawns. The bug occurs when the player (vip) has defuser and the cvar, that gives defuser at spawn, is set to 0 the defuser will disappear.
